### PR TITLE
Add GET /events/{event_id}/tickets endpoint with email/phone filters

### DIFF
--- a/schemas/public.json
+++ b/schemas/public.json
@@ -212,16 +212,18 @@
           {
             "in": "query",
             "name": "email",
-            "description": "Filter by attendee email (exact match)",
+            "description": "Filter by attendee email (contains, case-insensitive). Sensitive: passing PII in URLs may be captured by access logs, proxies, and browser history. Prefer transmitting over TLS only, avoid logging request URLs, and rotate logs that may contain this value.",
             "type": "string",
-            "required": false
+            "required": false,
+            "x-sensitive": true
           },
           {
             "in": "query",
             "name": "phone",
-            "description": "Filter by attendee phone number (exact match)",
+            "description": "Filter by attendee phone number (contains). Sensitive: passing PII in URLs may be captured by access logs, proxies, and browser history. Prefer transmitting over TLS only, avoid logging request URLs, and rotate logs that may contain this value.",
             "type": "string",
-            "required": false
+            "required": false,
+            "x-sensitive": true
           },
           {
             "in": "query",
@@ -310,6 +312,9 @@
             }
           },
           "401": { "description": "Unauthorized" },
+          "403": {
+            "description": "Forbidden - Organizer scope required or application not owned by organizer"
+          },
           "404": { "description": "Event not found" }
         },
         "tags": ["Organizer Resources"],

--- a/schemas/public.json
+++ b/schemas/public.json
@@ -189,6 +189,132 @@
       }
     },
     "/organizers/{organizer_id}/events/{event_id}/tickets": {
+      "get": {
+        "summary": "Get all tickets for an event with pagination and filtering",
+        "description": "Returns a paginated list of tickets for the specified event. Supports filtering by status, ticket type, email, phone, and date ranges. Use `email` filter to check if a specific attendee has registered for the event. Requires User Access Token with `organizer` scope.",
+        "produces": ["application/json"],
+        "parameters": [
+          {
+            "in": "query",
+            "name": "status",
+            "description": "Filter by status (comma-separated, e.g., \"active,used\")",
+            "type": "string",
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "ticket_type_id",
+            "description": "Filter by ticket type ID",
+            "type": "integer",
+            "format": "int32",
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "email",
+            "description": "Filter by attendee email (exact match)",
+            "type": "string",
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "phone",
+            "description": "Filter by attendee phone number (exact match)",
+            "type": "string",
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "updated_before",
+            "description": "Filter tickets updated before this time (ISO 8601)",
+            "type": "string",
+            "format": "date-time",
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "updated_after",
+            "description": "Filter tickets updated after this time (ISO 8601)",
+            "type": "string",
+            "format": "date-time",
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "max_id",
+            "description": "Tickets with ID less than this value (for deep pagination)",
+            "type": "integer",
+            "format": "int32",
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "min_id",
+            "description": "Tickets with ID greater than this value (for deep pagination)",
+            "type": "integer",
+            "format": "int32",
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "order_by",
+            "type": "string",
+            "default": "id",
+            "enum": ["id", "created_at", "updated_at", "used_at", "reference_code"],
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "order",
+            "type": "string",
+            "default": "asc",
+            "enum": ["asc", "desc"],
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "page",
+            "type": "integer",
+            "format": "int32",
+            "default": 1,
+            "required": false
+          },
+          {
+            "in": "query",
+            "name": "per_page",
+            "type": "integer",
+            "format": "int32",
+            "default": 10,
+            "required": false
+          },
+          {
+            "in": "path",
+            "name": "organizer_id",
+            "type": "integer",
+            "format": "int32",
+            "required": true
+          },
+          {
+            "in": "path",
+            "name": "event_id",
+            "type": "integer",
+            "format": "int32",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "List all tickets in event",
+            "schema": {
+              "$ref": "#/definitions/PublicAPI_Entities_TicketsListResponse"
+            }
+          },
+          "401": { "description": "Unauthorized" },
+          "404": { "description": "Event not found" }
+        },
+        "tags": ["Organizer Resources"],
+        "operationId": "getOrganizersOrganizerIdEventsEventIdTickets"
+      },
       "post": {
         "summary": "Create a new ticket for an event",
         "description": "Creates a ticket via API for external ticketing systems. Requires User Access Token with organizer scope.",
@@ -626,6 +752,41 @@
         }
       },
       "description": "PublicAPI_Entities_TicketResponse model"
+    },
+    "PublicAPI_Entities_TicketsListResponse": {
+      "type": "object",
+      "properties": {
+        "success": {
+          "type": "boolean",
+          "description": "Operation success status"
+        },
+        "tickets": {
+          "type": "array",
+          "items": { "$ref": "#/definitions/PublicAPI_Entities_Ticket" },
+          "description": "List of tickets"
+        },
+        "count": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of tickets in current page"
+        },
+        "total": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Total number of tickets matching query"
+        },
+        "page": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Current page number"
+        },
+        "per_page": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Number of items per page"
+        }
+      },
+      "description": "Paginated list of tickets"
     },
     "PublicAPI_Entities_Order": {
       "type": "object",


### PR DESCRIPTION
## Summary
- Add documentation for `GET /organizers/{organizer_id}/events/{event_id}/tickets` endpoint (Organizer Resources)
- Supports filtering by `email`, `phone`, `status`, `ticket_type_id`, date ranges, and ID-based deep pagination
- Enables organizers to check if a specific attendee has registered for their event
- Add `TicketsListResponse` definition for paginated response schema

## Test plan
- [ ] Verify the new endpoint renders correctly on docs.eventpop.me
- [ ] Confirm all query parameters display with correct types and descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/eventpop/codesmith/docs/pr/6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Codesmith can help with this PR, just tag <code>@codesmith</code> or enable autofix. <a href="https://app.blacksmith.sh/eventpop/settings?tab=codesmith">Settings</a>.</sup>

- [ ] Autofix CI and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added organizer-scoped ticket list for events, letting organizers view tickets for a specific event.
  * Enables filtering by status, ticket type, attendee email/phone (treated as sensitive), and updated date range.
  * Supports sorting, deep pagination (min/max id bounds) and returns pagination metadata for large-result navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->